### PR TITLE
De-namespace `mocked-component-opts` key

### DIFF
--- a/src/sweet_tooth/endpoint/system.clj
+++ b/src/sweet_tooth/endpoint/system.clj
@@ -88,13 +88,13 @@
   replace the original component's config so that the mocked
   component can be initialized.
 
-  `::mocked-component-opts` defines additional config opts that should
+  `:st/mocked-component-opts` defines additional config opts that should
   get passed to the mocked component. One use for this is to satisfy
   that component's config spec."
   ([] (shrubbery-mock {}))
-  ([{:keys [::mocked-component-opts] :as opts}]
+  ([{:keys [:st/mocked-component-opts] :as opts}]
    (merge {::init-key-alternative ::shrubbery-mock
-           ::shrubbery-mock       (dissoc opts ::mocked-component-opts)}
+           ::shrubbery-mock       (dissoc opts :st/mocked-component-opts)}
           mocked-component-opts)))
 
 (s/fdef shrubbery-mock

--- a/test/sweet_tooth/endpoint/system_test.clj
+++ b/test/sweet_tooth/endpoint/system_test.clj
@@ -86,7 +86,7 @@
   (is (= {::es/init-key-alternative :sweet-tooth.endpoint.system/shrubbery-mock
           ::es/shrubbery-mock       {:foo :bar}
           :baz                      :boop}
-         (es/shrubbery-mock {:foo                       :bar
-                             ::es/mocked-component-opts {:baz :boop}}))))
+         (es/shrubbery-mock {:foo                      :bar
+                             :st/mocked-component-opts {:baz :boop}}))))
 
 (es/system ::alternative-test {::b (es/shrubbery-mock {Stubby {:blurm "blurmed!"}})})


### PR DESCRIPTION
Because using `:sweet-tooth.endpoint.system/mocked-component-opts` in EDN config files are a bit unwieldy. This is also visually closer to `#st/shrubbery-mock`.

There is a question of backwards compatibility: is a hard switch-over like this acceptable?